### PR TITLE
Add color function

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ xmllint
 ```
 ./wled-cmd 192.168.1.147 on
 ./wled-cmd 192.168.1.147 color 255 0 0
+./wled-cmd 192.168.1.147 color ff0000
 ./wled-cmd 192.168.1.147 brightness 128
 ./wled-cmd 192.168.1.147 cycle (this one cycles through a list of effects in the script)
 ./wled-cmd 192.168.1.147 fx 68

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ xmllint
 # usage
 ```
 ./wled-cmd 192.168.1.147 on
+./wled-cmd 192.168.1.147 color 255 0 0
 ./wled-cmd 192.168.1.147 brightness 128
 ./wled-cmd 192.168.1.147 cycle (this one cycles through a list of effects in the script)
 ./wled-cmd 192.168.1.147 fx 68

--- a/wled-cmd
+++ b/wled-cmd
@@ -4,7 +4,7 @@ usage() {
 }
 
 color_help() {
-  echo -e "Usage: $0 ipaddress color [0-255] [0-255] [0-255]"
+  echo -e "Usage: \t$0 ipaddress color [0-255] [0-255] [0-255]\n\t$0 ipaddress color [hex]"
 }
 
 if [[ $1 =~ ^(([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))\.){3}([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))$ ]]; then
@@ -61,16 +61,22 @@ set_brightness() {
 }
 
 color() {
-  R=$1
-  G=$2
-  B=$3
-  if [[ ! "$R" || ! "$G" || ! "$B" ]];
+  if [[ $# -eq 1 ]];
   then
+	hex="h$1"
+    echo "Setting color to 0x$1"
+	return=$(curl -s -o /dev/null -w "%{http_code}\n" "http://$ip/win&CL=$hex")
+  elif [[ $# -eq 3 ]];
+  then
+    R=$1
+    G=$2
+    B=$3
+    echo "Setting color to Red=$R Green=$G Blue=$B"
+    return=$(curl -s -o /dev/null -w "%{http_code}\n" "http://$ip/win&R=$R&G=$G&B=$B")
+  else
     color_help
     exit 1
   fi
-  echo "Setting color to Red=$R Green=$G Blue=$B"
-  return=$(curl -s -o /dev/null -w "%{http_code}\n" "http://$ip/win&R=$R&G=$G&B=$B")
   http_code $return
 }
 

--- a/wled-cmd
+++ b/wled-cmd
@@ -1,6 +1,10 @@
 #!/bin/bash
 usage() {
-  echo "Usage: $0 ipaddress {on|off|get_brightness|set_brightness|cycle|fx fx_num|status}"
+  echo "Usage: $0 ipaddress {on|off|color|get_brightness|set_brightness|cycle|fx fx_num|status}"
+}
+
+color_help() {
+  echo -e "Usage: $0 ipaddress color [0-255] [0-255] [0-255]"
 }
 
 if [[ $1 =~ ^(([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))\.){3}([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))$ ]]; then
@@ -57,14 +61,16 @@ set_brightness() {
 }
 
 color() {
-  CL=$1
-  if [[ ! "$CL" ]];
+  R=$1
+  G=$2
+  B=$3
+  if [[ ! "$R" || ! "$G" || ! "$B" ]];
   then
     color_help
     exit 1
   fi
-  echo "Setting color to $CL"
-  return=$(curl -s -o /dev/null -w "%{http_code}\n" "http://$ip/win&CL=$CL")
+  echo "Setting color to Red=$R Green=$G Blue=$B"
+  return=$(curl -s -o /dev/null -w "%{http_code}\n" "http://$ip/win&R=$R&G=$G&B=$B")
   http_code $return
 }
 
@@ -151,6 +157,9 @@ case "$2" in
        ;;
     status)
        status
+       ;;
+    color)
+       color $3 $4 $5
        ;;
     *)
        echo "Missing command"


### PR DESCRIPTION
This PR enables setting the color with: `wled-cmd ip color r g b`

Running `wled-cmd 192.168.1.147 color 255 0 0` or `wled-cmd 192.168.1.147 color ff0000` will set the color to red.